### PR TITLE
Update MyTable.js

### DIFF
--- a/frontend/src/components/Admin/MyTable.js
+++ b/frontend/src/components/Admin/MyTable.js
@@ -13,7 +13,11 @@ const MyTable = ({ onRowSelectionModelChange }) => {
     axios
       .get(BASEURL+"/user/manager/verification")
       .then((response) => {
-        setRows(response.data.requests);
+        if(response.data && response.data.requests) {
+          setRows(response.data.requests);
+        } else {
+          setRows([]);
+        }
       });
   }, []);
 


### PR DESCRIPTION
관리자 인증 페이지에서 데이터가 없을 경우 오류가 뜨는 것이 아닌 No rows가 되도록 변경